### PR TITLE
Fix the URL of "Open Cloud Shell" button image

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If `project_create` is left to null, the identity performing the deployment need
 
 If you want to deploy from your Cloud Shell, click on the image below, sign in if required and when the prompt appears, click on “confirm”.
 
-[![Open Cloudshell](../../../../assets/images/cloud-shell-button.png)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fcloud-foundation-fabric&cloudshell_workspace=blueprints%2Fthird-party-solutions%2Fwordpress%2Fcloudrun)
+[![Open Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fcloud-foundation-fabric&cloudshell_workspace=blueprints%2Fthird-party-solutions%2Fwordpress%2Fcloudrun)
 
 Otherwise, in your console of choice:
 


### PR DESCRIPTION
Hi, I noticed the "Open Cloud Shell" button image was broken in `README.md` (I guess because it was referring to the internal repository file 🙂). 

This PR fixes the image URL. I used the image explained in the official documentation: [Open in Cloud Shell  |  Google Cloud](https://cloud.google.com/shell/docs/open-in-cloud-shell).